### PR TITLE
Add `/calendar` page with embedded Google Calendar

### DIFF
--- a/calendar/index.html
+++ b/calendar/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta content="initial-scale=1.0" name="viewport">
+<title>WebOfTrust Community Calendar</title>
+<style type="text/css">
+@import url('https://fonts.googleapis.com/css?family=Noto+Sans'); /* Sans-serif */
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono'); /* Monospace */
+@viewport {
+  zoom: 1.0;
+  width: extend-to-zoom;
+}
+@-ms-viewport {
+  width: extend-to-zoom;
+  zoom: 1.0;
+}
+html {
+}
+body {
+  max-width: 90%;
+  margin: 1.5em auto;
+  color: #222;
+  background-color: #fff;
+  font-size: 14px;
+  font-family: 'Noto Sans', Arial, Helvetica, sans-serif;
+  line-height: 1.6;
+  scroll-behavior: smooth;
+}
+#title, h1, h2, h3, h4, h5, h6 {
+  margin: 1em 0 0.5em;
+  font-weight: bold;
+  line-height: 1.3;
+}
+#title {
+  clear: both;
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 0.5em 0;
+  padding: 1em 0 0.5em;
+}
+h1 {
+  font-size: 26px;
+  margin: 1em 0;
+}
+h2 {
+  font-size: 22px;
+  margin-top: -20px;  /* provide offset for in-page anchors */
+  padding-top: 33px;
+}
+h3 {
+  font-size: 18px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h4 {
+  font-size: 16px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h5, h6 {
+  font-size: 14px;
+}
+p {
+  padding: 0;
+  margin: 0 0 1em 0;
+  text-align: left;
+}
+div, span {
+  position: relative;
+}
+div {
+  margin: 0;
+}
+ol, ul {
+  padding: 0;
+  margin: 0 0 1em 2em;
+}
+ol ol, ul ul, ol ul, ul ol {
+  margin-left: 1em;
+}
+li {
+  margin: 0 0 0.25em 0;
+}
+a {
+  text-decoration: none;
+}
+a[href] {
+  color: #22e;
+}
+a[href]:hover {
+  background-color: #f2f2f2;
+}
+tt, code, pre, code {
+  background-color: #f9f9f9;
+  font-family: 'Roboto Mono', monospace;
+}
+pre {
+  border: 1px solid #eee;
+  margin: 0;
+  padding: 1em;
+}
+img {
+  max-width: 100%;
+}
+@media screen {
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+    max-width: calc(100% - 22px);
+  }
+}
+@media screen and (min-width: 1024px) {
+  body {
+    max-width: 724px;
+    margin: 42px auto;
+    padding-left: 1.5em;
+    padding-right: 29em;
+  }
+}
+</style>
+</head>
+<body>
+    <header>
+        <h1 id="title">WebOfTrust Community Calendar</h1>
+    </header>
+    <main>
+        <iframe src="https://calendar.google.com/calendar/embed?src=742759772026f5a242363e269a8b8ed281af2e4113386eac4ad154acb807a4e8%40group.calendar.google.com&ctz=America%2FNew_York&showTitle=0" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+        <ul>
+            <li><a href='webcal://calendar.google.com/calendar/ical/742759772026f5a242363e269a8b8ed281af2e4113386eac4ad154acb807a4e8%40group.calendar.google.com/public/basic.ics'>Webcal</a></li>
+            <li><a href='https://calendar.google.com/calendar/ical/742759772026f5a242363e269a8b8ed281af2e4113386eac4ad154acb807a4e8%40group.calendar.google.com/public/basic.ics'>Direct .ics</a></li>
+        </ul>
+    </main>
+</html>


### PR DESCRIPTION
Adds a `/calendar` page which embeds a publicly accessible Google Calendar widget. The calendar currently contains the Tuesday and Thursday community calls with their respective Zoom links.

I created this calendar and am happy to add any and all other relevant people with full admin rights. Or, create a new one and update the embedding code.

Calendar:
https://calendar.google.com/calendar/u/0/embed?src=742759772026f5a242363e269a8b8ed281af2e4113386eac4ad154acb807a4e8@group.calendar.google.com

Direct .ics link:
https://calendar.google.com/calendar/ical/742759772026f5a242363e269a8b8ed281af2e4113386eac4ad154acb807a4e8%40group.calendar.google.com/public/basic.ics

Webcal URL:
webcal://calendar.google.com/calendar/ical/742759772026f5a242363e269a8b8ed281af2e4113386eac4ad154acb807a4e8%40group.calendar.google.com/public/basic.ics